### PR TITLE
WIP: Int4 support

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "safetensors-python"
-version = "0.5.3-dev.0"
+name = "miraitensors"
+version = "0.5.4-dev.0"
 edition = "2021"
 rust-version = "1.74"
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -2,7 +2,10 @@
 name = 'safetensors'
 requires-python = '>=3.7'
 authors = [
-    {name = 'Nicolas Patry', email = 'patry.nicolas@protonmail.com'}
+    { name = 'Nicolas Patry', email = 'patry.nicolas@protonmail.com' },
+    { name = 'Vladimir Vlasiuk', email = 'matterai.net@gmail.com' },
+    { name = 'Artur Chakhvadze', email = 'norpadon@gmail.com' },
+    { name = 'Eugene Bokhan', email = 'eugenebokhan@icloud.com' },
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -19,12 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Typing :: Typed",
 ]
-dynamic = [
-    'description',
-    'license',
-    'readme',
-    'version',
-]
+dynamic = ['description', 'license', 'readme', 'version']
 
 [project.urls]
 Homepage = 'https://github.com/huggingface/safetensors'
@@ -32,34 +30,15 @@ Source = 'https://github.com/huggingface/safetensors'
 
 [project.optional-dependencies]
 numpy = ["numpy>=1.21.6"]
-torch = [
-    "safetensors[numpy]",
-    "torch>=1.10",
-]
-tensorflow = [
-    "safetensors[numpy]",
-    "tensorflow>=2.11.0",
-]
+torch = ["safetensors[numpy]", "torch>=1.10"]
+tensorflow = ["safetensors[numpy]", "tensorflow>=2.11.0"]
 # pinning tf version 2.11.0 for doc-builder
-pinned-tf = [
-    "safetensors[numpy]",
-    "tensorflow==2.18.0",
-]
-jax = [
-    "safetensors[numpy]",
-    "flax>=0.6.3",
-    "jax>=0.3.25",
-    "jaxlib>=0.3.25",
-]
-mlx = [
-    "mlx>=0.0.9",
-]
-paddlepaddle = [
-    "safetensors[numpy]",
-    "paddlepaddle>=2.4.1",
-]
+pinned-tf = ["safetensors[numpy]", "tensorflow==2.18.0"]
+jax = ["safetensors[numpy]", "flax>=0.6.3", "jax>=0.3.25", "jaxlib>=0.3.25"]
+mlx = ["mlx>=0.0.9"]
+paddlepaddle = ["safetensors[numpy]", "paddlepaddle>=2.4.1"]
 quality = [
-    "black==22.3",  # after updating to black 2023, also update Python version in pyproject.toml to 3.7
+    "black==22.3",   # after updating to black 2023, also update Python version in pyproject.toml to 3.7
     "click==8.0.4",
     "isort>=5.5.4",
     "flake8>=3.8.3",
@@ -83,9 +62,10 @@ all = [
     "safetensors[quality]",
     "safetensors[testing]",
 ]
-dev = [
-    "safetensors[all]",
-]
+dev = ["safetensors[all]"]
+
+[tool.twine.repository]
+url = "https://europe-west2-python.pkg.dev/mirai-430618/pypi-pypi/"
 
 
 [build-system]
@@ -103,4 +83,4 @@ line-length = 119
 target-version = ['py35']
 
 [tool.setuptools.dynamic]
-readme = {file = ["README.rst"]}
+readme = { file = ["README.rst"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = 'safetensors'
+name = 'miraitensors'
 requires-python = '>=3.7'
 authors = [
     { name = 'Nicolas Patry', email = 'patry.nicolas@protonmail.com' },

--- a/safetensors/benches/benchmark.rs
+++ b/safetensors/benches/benchmark.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 fn get_sample_data() -> (Vec<u8>, Vec<usize>, Dtype) {
     let shape = vec![1000, 500];
     let dtype = Dtype::F32;
-    let n: usize = shape.iter().product::<usize>() * dtype.size(); // 4
+    let n: usize = compute_size(dtype, &shape);
     let data = vec![0; n];
 
     (data, shape, dtype)

--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -257,7 +257,7 @@ impl<'data> SliceIterator<'data> {
         let mut newshape = Vec::with_capacity(view.shape().len());
 
         // Minimum span is the span of 1 item;
-        let mut span = view.dtype().size();
+        let mut span = view.dtype().size_in_bits() / 8;
         let mut indices = vec![];
         // Everything is row major.
         for (i, &shape) in view.shape().iter().enumerate().rev() {

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -182,7 +182,6 @@ fn serialize_i4(shape: &[usize], data: &[i8]) -> Vec<u8> {
 /// Deserializes a byte buffer into a tensor of type INT4.
 /// Assumes the buffer is correctly formatted.
 fn deserialize_i4(shape: &[usize], packed: &[u8]) -> Vec<i8> {
-    // 2 x 3,  55u8, 240, 130, 176
     let (rows, cols) = compute_rows_cols(shape);
     let count = rows * cols;
     let mut buffer: Vec<i8> = Vec::with_capacity(count);

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -1111,22 +1111,6 @@ mod tests {
         assert_eq!(high, unpacked_high);
     }
 
-    // #[test]
-    // fn test_bytes_size() {
-    //     let data: Vec<u8> = vec![55u8, 248, 43]
-    //         .into_iter()
-    //         .flat_map(|f| {
-    //             let byte = f as u8;
-    //             let (low, high) = unpack_u4(byte);
-    //             vec![high, low]
-    //         })
-    //         .collect();
-    //     let shape = vec![3];
-    //     let attn_0 = TensorView::new(Dtype::U4, shape, &data).unwrap();
-    //     let len = attn_0.data_len();
-    //     assert_eq!(3, len);
-    // }
-
     #[test]
     fn test_roundtrip_1d_i4() {
         let shape = vec![6];
@@ -1205,33 +1189,25 @@ mod tests {
         assert_eq!(data, unpacked);
     }
 
-    // #[test]
-    // fn test_prepare() {
-    //     // Bits:      0011_0111 1111_1000 0010_1011
-    //     // Bytes:     55        248       43
-    //     // INT4:      3    7    -1   -8   2    -5
-    //     let packed: Vec<u8> = vec![0x37, 0xF8, 0x2B];
+    #[test]
+    fn test_tensor_data_len_1d() {
+        let shape = vec![6];
+        let data: Vec<u8> = vec![55u8, 248, 43];
 
-    //     println!("Raw bytes as bits:");
-    //     for byte in &packed {
-    //         print!("{byte:08b} ");
-    //     }
+        let attn_0 = TensorView::new(Dtype::U4, shape, &data).unwrap();
+        let len = attn_0.data_len();
+        assert_eq!(3, len);
+    }
 
-    //     let mut unpacked = Vec::new();
-    //     for byte in &packed {
-    //         let (low, high) = unpack_i4(*byte);
-    //         unpacked.push(high);
-    //         unpacked.push(low);
-    //     }
+    #[test]
+    fn test_tensor_data_len_3d() {
+        let shape = vec![2, 2, 2];
+        let data: Vec<u8> = vec![63u8, 24, 44, 23];
 
-    //     assert_eq!(unpacked.len(), 6);
-    //     assert_eq!(unpacked, vec![3, 7, -1, -8, 2, -5]);
-
-    //     println!("\n\nUnpacked INT4 values:");
-    //     for val in unpacked {
-    //         print!("{:>3} ", val);
-    //     }
-    // }
+        let attn_0 = TensorView::new(Dtype::U4, shape, &data).unwrap();
+        let len = attn_0.data_len();
+        assert_eq!(4, len);
+    }
 
     #[test]
     fn test_serialization() {

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -1209,6 +1209,23 @@ mod tests {
     }
 
     #[test]
+    fn test_packed_i4_roundtrip_3d_tensor() {
+        let shape = vec![1, 2, 3];
+        let data: Vec<i8> = vec![3, -2, 1, 7, -1, -7];
+        let packed: Vec<u8> = serialize_i4(&shape, &data);
+
+        let attn_0 = TensorView::new(Dtype::PackedI4, shape, &packed).unwrap();
+        let metadata: HashMap<String, TensorView> =
+            [("attn.0".to_string(), attn_0)].into_iter().collect();
+
+        let out = serialize(&metadata, &None).unwrap();
+        println!("{:?}", out);
+
+        let parsed = SafeTensors::deserialize(&out).unwrap();
+        println!("{:?}", parsed);
+    }
+
+    #[test]
     fn test_serialization() {
         let data: Vec<u8> = vec![0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0]
             .into_iter()

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -163,7 +163,7 @@ fn compute_rows_cols(shape: &[usize]) -> (usize, usize) {
 
 /// Serializes a tensor of type INT4 into a byte buffer.
 /// Uses padding to ensure shape is a multiple of 2.
-fn serialize_i4(shape: &[usize], data: &[i8]) -> Vec<u8> {
+pub fn serialize_i4(shape: &[usize], data: &[i8]) -> Vec<u8> {
     let (rows, cols) = compute_rows_cols(shape);
     let mut buffer: Vec<u8> = Vec::with_capacity(rows * (cols / 2 + cols % 2));
     for row in 0..rows {
@@ -181,7 +181,7 @@ fn serialize_i4(shape: &[usize], data: &[i8]) -> Vec<u8> {
 
 /// Deserializes a byte buffer into a tensor of type INT4.
 /// Assumes the buffer is correctly formatted.
-fn deserialize_i4(shape: &[usize], packed: &[u8]) -> Vec<i8> {
+pub fn deserialize_i4(shape: &[usize], packed: &[u8]) -> Vec<i8> {
     let (rows, cols) = compute_rows_cols(shape);
     let count = rows * cols;
     let mut buffer: Vec<i8> = Vec::with_capacity(count);
@@ -202,7 +202,7 @@ fn deserialize_i4(shape: &[usize], packed: &[u8]) -> Vec<i8> {
 
 /// Serializes a tensor of type UINT4 into a byte buffer.
 /// Assumes the tensor is correctly formatted.
-fn serialize_u4(shape: &[usize], data: &[u8]) -> Vec<u8> {
+pub fn serialize_u4(shape: &[usize], data: &[u8]) -> Vec<u8> {
     let (rows, cols) = compute_rows_cols(shape);
     let mut buffer: Vec<u8> = Vec::with_capacity(rows * (cols / 2 + cols % 2));
     for row in 0..rows {
@@ -220,7 +220,7 @@ fn serialize_u4(shape: &[usize], data: &[u8]) -> Vec<u8> {
 
 /// Deserializes a tensor of type UINT4 from a byte buffer.
 /// Assumes the buffer is correctly formatted.
-fn deserialize_u4(shape: &[usize], packed: &[u8]) -> Vec<u8> {
+pub fn deserialize_u4(shape: &[usize], packed: &[u8]) -> Vec<u8> {
     let (rows, cols) = compute_rows_cols(shape);
     let count = rows * cols;
     let mut buffer: Vec<u8> = Vec::with_capacity(count);


### PR DESCRIPTION
PR introduces specific handling for INT4 tensors in the safetensors library, changing size computation to work with bit-level precision rather than byte-level. It adds U4 and I4 data types and properly handles their memory layout requirements.